### PR TITLE
Update yomu.rb

### DIFF
--- a/lib/yomu.rb
+++ b/lib/yomu.rb
@@ -9,7 +9,7 @@ require 'stringio'
 
 class Yomu
   GEMPATH = File.dirname(File.dirname(__FILE__))
-  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.11.jar')
+  JARPATH = File.join(Yomu::GEMPATH, 'jar', 'tika-app-1.17.jar')
   DEFAULT_SERVER_PORT = 9293 # an arbitrary, but perfectly cromulent, port
 
   @@server_port = nil


### PR DESCRIPTION
Bump tika to 1.17.  Need to add tika-app-1.17.jar in /jar directory.

This may create some additional dependencies, such as sqlite-jdbc (see tika's pom file):

Mar 19, 2018 1:33:03 PM org.apache.tika.config.InitializableProblemHandler$3 handleInitializableProblem
WARNING: org.xerial's sqlite-jdbc is not loaded.
Please provide the jar on your classpath to parse sqlite files.
See tika-parsers/pom.xml for the correct version.

... and others:

WARNING: JBIG2ImageReader not loaded. jbig2 files will be ignored
See https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io
for optional dependencies.
TIFFImageWriter not loaded. tiff files will not be processed
See https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io
for optional dependencies.
J2KImageReader not loaded. JPEG2000 files will not be processed.
See https://pdfbox.apache.org/2.0/dependencies.html#jai-image-io
for optional dependencies.

As an example, running this on a PDF locally.